### PR TITLE
Modal cleanup

### DIFF
--- a/js/cookie-settings.min.js
+++ b/js/cookie-settings.min.js
@@ -461,7 +461,6 @@
             var settings_title = _createNode('div');
             var settings_header = _createNode('div');
             var settings_close_btn = _createNode('button');
-            var settings_close_btn_container = _createNode('div');
             var settings_blocks = _createNode('div');
             var overlay = _createNode('div');
 
@@ -478,7 +477,6 @@
             settings_blocks.id = 's-bl';
             settings_close_btn.id = 's-c-bn';
             overlay.id = 'cs-ov';
-            settings_close_btn_container.id = 's-c-bnc';
           
             /**
              * Set classes
@@ -489,7 +487,6 @@
             settings_inner.className = 'modal-content';
             settings_header.className = "modal-header";
             settings_title.className = 'h5 modal-title';
-            settings_close_btn_container.className = 'd-flex';
             settings_close_btn.className = 'c-bn btn-close';
             settings_blocks.className = 'modal-body';
 
@@ -505,8 +502,6 @@
             settings_title.setAttribute('role', 'heading');
             settings_container.style.visibility = overlay.style.visibility = "hidden";
             overlay.style.opacity = 0;
-
-            settings_close_btn_container.appendChild(settings_close_btn);
 
             // If 'esc' key is pressed inside settings_container div => hide settings
             _addEvent(settings_container_inner, 'keydown', function(evt){
@@ -817,7 +812,7 @@
             });
 
             settings_header.appendChild(settings_title);
-            settings_header.appendChild(settings_close_btn_container);
+            settings_header.appendChild(settings_close_btn);
 
             settings_inner.appendChild(settings_header);
             settings_inner.appendChild(settings_blocks);
@@ -2051,7 +2046,6 @@
         window[init] = CookieConsent
     }
 })();
-
 
 
 


### PR DESCRIPTION
- Removed `settings_close_btn_container` div wrapper for btn-close
- Removed `div settings_container_valign`
- Set `settings_container` to `child settings_container_inner`